### PR TITLE
Update locateChart to work for any chart version pinning

### DIFF
--- a/openunison/deployer.go
+++ b/openunison/deployer.go
@@ -1332,8 +1332,8 @@ func (ou *OpenUnisonDeployment) locateChart(configChartName string, chartPathOpt
 	chartName := configChartName
 	chartVersion := ""
 	if strings.Contains(configChartName, "@") {
-		chartName = ou.operator.chart[0:strings.Index(ou.operator.chart, "@")]
-		chartVersion = ou.operator.chart[strings.Index(ou.operator.chart, "@")+1:]
+		chartName = configChartName[0:strings.Index(configChartName, "@")]
+		chartVersion = configChartName[strings.Index(configChartName, "@")+1:]
 
 		fmt.Printf("Chart version specified for %s: %s\n", chartName, chartVersion)
 


### PR DESCRIPTION
# Background

This change addresses the issue outlined in https://github.com/TremoloSecurity/openunison-control/issues/27, making the `locateChart` function truly  generic. This was nearly done, but the operator chart + version was referenced in this function, so no matter what chart and/or version you specify, it will always reference the value of the `--operator-chart` flag.

Current behavior:

```bash

```

# What does this PR do?
This PR simply replaces what string is referenced in parsing the chart name + version to be the function input variable `configChartName`.